### PR TITLE
Error after hearth

### DIFF
--- a/Core/Global/Namespace.lua
+++ b/Core/Global/Namespace.lua
@@ -259,6 +259,11 @@ local function NameSpacePropertiesAndMethods(o)
     function o:ToStringNamespaceKeys() return self.pformat(getSortedKeys(self)) end
     function o:ToStringObjectKeys() return self.pformat(getSortedKeys(self.O)) end
 
+    --- @return LibDataBroker
+    function o:LibDataBroker() return LibStub("LibDataBroker-1.1") end
+    --- @return LibDBIcon
+    function o:LibDBIcon() return LibStub("LibDBIcon-1.0") end
+
     InitLocalLibStub(o)
 end
 

--- a/Core/Lib/MinimapIconController.lua
+++ b/Core/Lib/MinimapIconController.lua
@@ -3,10 +3,11 @@ Local Vars
 -------------------------------------------------------------------------------]]
 --- @type Namespace
 local ns = select(2, ...)
-local O, GC, MSG = ns.O, ns.GC, ns.GC.M
+local MSG = ns.GC.M
 
-local LibDBIcon = ns.LibStubAce("LibDBIcon-1.0")
-local LibDataBroker = ns.LibStubAce("LibDataBroker-1.1")
+local LibDBIcon = ns:LibDBIcon()
+local LibDataBroker = ns:LibDataBroker()
+
 local L = ns:AceLocale()
 local minimapName = ns.name .. "MinimapIcon"
 local libName = 'MinimapIconController'
@@ -17,7 +18,6 @@ New Instance
 local S = ns:NewLibWithEvent(libName)
 local p = ns:CreateDefaultLogger(libName)
 local pm = ns:LC().MESSAGE:NewLogger(libName)
-p:v(function() return "Loaded: %s", libName end)
 
 --[[-----------------------------------------------------------------------------
 Methods
@@ -53,12 +53,23 @@ local function PropsAndMethods(o)
 
     --- @public
     function o:InitMinimapIcon()
-        if ns.AddonSuiteDropdownMenu then return end
-
+        self:CreateAndRegisterMinimapDataObject()
+    end
+    --- @public
+    function o:CreateAndRegisterMinimapDataObject()
         local mainSelf = self
         local A = self.addon
         local icon = "inv_cask_01"
-        local dataObject = LibDataBroker:NewDataObject(ns.name .. "Minimap", {
+        local minimapObjectName = ns.name .. "Minimap"
+        --- @type LibDataBroker_DataObject
+        local dataObject = LibDataBroker:GetDataObjectByName(minimapObjectName)
+        if dataObject then
+            p:d(function() return 'LibDataBroker-DataObject already registered: %s',
+                    tostring(type(dataObject) ~= nil) end)
+            return
+        end
+
+        dataObject = LibDataBroker:NewDataObject(minimapObjectName, {
             type = "data source",
             text = ns.GC.C.FRIENDLY_NAME,
             icon = "Interface\\Icons\\" .. icon,


### PR DESCRIPTION
Fixes #6: Error after hearth.
Second attempt to fix. Now checks to see if the LDB Object was previously created. The behavior after hearthing and teleporting is not a full reload of addons.