### PR TITLE
Hide Minimap Icon When Added to TitanPanel is broken

### DIFF
--- a/Core/Lib/MinimapIconController.lua
+++ b/Core/Lib/MinimapIconController.lua
@@ -271,7 +271,10 @@ local function PropsAndMethods(o)
     function o:New() return ns:K():CreateAndInitFromMixin(o) end
 
     --- @public
-    function o:InitMinimapIcon() self:CreateAndRegisterMinimapDataObject() end
+    function o:InitMinimapIcon()
+        self:CreateAndRegisterMinimapDataObject()
+        OnToggleMinimapIconTitanPanel(self)
+    end
 
     --- @public
     function o:CreateAndRegisterMinimapDataObject()


### PR DESCRIPTION
Resolves #43: Hide Minimap Icon When Added to TitanPanel is broken