### PR TITLE
Hide Minimap Icon When TitanPanel broken

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,10 +1,9 @@
 ---
 name: Bug report
-about: Create a report to help improve the ActionbarPlus Add-On
+about: Create a report to help improve the Add-On
 title: ''
 labels: ''
 assignees: ''
-
 ---
 
 **Describe the bug**

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,10 +1,9 @@
 ---
 name: Feature request
-about: Suggest an idea for ActionbarPlus Add-On
+about: Suggest an idea for the Add-On
 title: ''
 labels: ''
 assignees: ''
-
 ---
 
 **Is your feature request related to a problem? Please describe.**

--- a/Core/Lib/API/AddOnManager.lua
+++ b/Core/Lib/API/AddOnManager.lua
@@ -165,6 +165,8 @@ local function AddonInfoPropsAndMethods(o)
     function o:GetNameAndDesc()
         local name = self.name
         local desc = string.gsub(self.notes or '', "[\|n]+$", "")
+        local title = GetAddOnMetadata(self.name, 'Title')
+        desc = title .. '\n\n' .. desc
         local label = ''
         local bullets = {}
 

--- a/Core/Lib/MinimapIconController.lua
+++ b/Core/Lib/MinimapIconController.lua
@@ -70,7 +70,9 @@ local function FC(hexColor, text) return ns.ch:FormatColor(hexColor, text) end
 local function FCOS(text) return ns.ch:FormatColor(textOutOfSyncColor, text) end
 
 local function IsHide() return ns:global().minimap.hide == true end
-local function IsShownInTP() return ns:db().char.shownInTitanPanel == true end
+local function IsShownInTP()
+    return API:IsTitanPanelAvailable() and ns:db().char.shownInTitanPanel == true
+end
 local function IsHideWhenInTP() return ns:global().minimap.hide_when_titan_panel_added == true end
 
 ---@param tooltip _GameTooltip
@@ -106,10 +108,11 @@ local function OnToggleMinimapIcon(self) self:SetShowOnMinimap(not IsHide()) end
 
 --- @param self MinimapIconController
 local function OnToggleMinimapIconTitanPanel(self)
+    local showInMM = true
     if IsHide() or (IsShownInTP() and IsHideWhenInTP()) then
-        return self:SetShowOnMinimap(false)
+        showInMM = false
     end
-    self:SetShowOnMinimap(true)
+    self:SetShowOnMinimap(showInMM)
 end
 
 --- @param self MinimapIconController

--- a/Core/Lib/OptionsMixin.lua
+++ b/Core/Lib/OptionsMixin.lua
@@ -44,6 +44,7 @@ local function MethodsAndProps(o)
         --@do-not-package@
         if ns.debug:IsDeveloper() then
             opt.args.debugging = DebugSettings:CreateDebuggingGroup()
+            p:a(function() return 'Debugging tab in Settings UI is enabled with LogLevel=%s', ADDON_SUITE_LOG_LEVEL end)
             return
         end
         --@end-do-not-package@


### PR DESCRIPTION
Fixes #43: Hide Minimap Icon When Added to TitanPanel is broken (Second Attempt)
- Add AddOn 'Title' to addon mouseover