### PR TITLE
Localize minimap tooltip strings

### DIFF
--- a/Core/Global/GlobalConstants.lua
+++ b/Core/Global/GlobalConstants.lua
@@ -20,6 +20,7 @@ local addon
 local ns
 addon, ns = ...
 local kch = ns.Kapresoft_LibUtil.CH
+local fVersion = ns:K():cf(BLUE_FONT_COLOR)
 
 local addonShortName = 'AddonSuite'
 local addonFriendlyName = 'Addon Suite'
@@ -173,6 +174,7 @@ local function Methods(o)
         return o.AddonUtil
     end
 
+    function o:GetAddOnTitle() return self.C.FRIENDLY_NAME .. fVersion(' v' .. self:GetAddonInfo()) end
 
     ---#### Example
     ---```

--- a/Core/Lib/Locales/enUS.lua
+++ b/Core/Lib/Locales/enUS.lua
@@ -98,6 +98,7 @@ L['Open minimap settings dialog'] = true
 L['View available commands']      = true
 L['Open settings dialog']         = true
 L['Command Lines']                = true
+L['Currently configured to load %s confirmation'] = true
 
 L['Add to Favorite']              = true
 L['Add to Favorite::Desc']        = "Enable this option to display the current profile in the minimap profile switch menu accessible with a LEFT-click, allowing for easy access. Disable to hide the profile from the menu."
@@ -125,6 +126,8 @@ L['SHIFT-RIGHT-Click']          = true
 
 L['Profile Sync Status Indicator']       = true
 L['Profile Sync Status Indicator::Desc'] = 'Enable this option to use |cfdE64750color|r coding on the minimap icon, visually indicating when your profile is synced or needs an update. This provides a quick and easy way to check your profile\'s status at a glance.'
+
+L['Open Debugging Dialog'] = true
 
 L['Enabled (After Reload)']  = true
 L['Disabled (After Reload)'] = true

--- a/Core/Lib/Locales/enUS.lua
+++ b/Core/Lib/Locales/enUS.lua
@@ -94,11 +94,11 @@ L['Hide Minimap Icon TitanPanel']       = 'Hide Minimap Icon When Added to Titan
 L['Hide Minimap Icon TitanPanel::Desc'] = 'Toggles the visibility of the addon\'s minimap icon when added to a TitanPanel, hiding it from view when enabled.'
 
 L['View or switch profiles']      = true
-L['Open minimap settings dialog'] = true
+L['Open minimap settings'] = true
 L['View available commands']      = true
-L['Open settings dialog']         = true
+L['Open settings']                = true
 L['Command Lines']                = true
-L['Currently configured to load %s confirmation'] = true
+L['Currently set to switch profiles %s a confirmation prompt.'] = true
 
 L['Add to Favorite']              = true
 L['Add to Favorite::Desc']        = "Enable this option to display the current profile in the minimap profile switch menu accessible with a LEFT-click, allowing for easy access. Disable to hide the profile from the menu."
@@ -127,7 +127,7 @@ L['SHIFT-RIGHT-Click']          = true
 L['Profile Sync Status Indicator']       = true
 L['Profile Sync Status Indicator::Desc'] = 'Enable this option to use |cfdE64750color|r coding on the minimap icon, visually indicating when your profile is synced or needs an update. This provides a quick and easy way to check your profile\'s status at a glance.'
 
-L['Open Debugging Dialog'] = true
+L['Open debug settings'] = true
 
 L['Enabled (After Reload)']  = true
 L['Disabled (After Reload)'] = true

--- a/Core/Lib/MinimapIconControllerMixin.lua
+++ b/Core/Lib/MinimapIconControllerMixin.lua
@@ -181,7 +181,7 @@ local function OnTooltipShow(self, tooltip)
     local currentProfileText, currentProfile = CurrentProfileText(inSync)
     local confirmationLine = GetConfirmReloadText()
 
-    local header1 = ns.sformat('%s %s', iconText, ns.ch:P(ns.GC.C.FRIENDLY_NAME))
+    local header1 = ns.sformat('%s %s', iconText, GC:GetAddOnTitle())
     local header3 = ns.sformat('%s: %s', currentProfileText, currentProfile)
 
     tooltip:AddDoubleLine(header1, header3)

--- a/Core/Lib/MinimapIconControllerMixin.lua
+++ b/Core/Lib/MinimapIconControllerMixin.lua
@@ -69,7 +69,7 @@ local function IsConfirmReload() return minimap().confirm_reloads == true end
 
 --- This local function is dynamic and needs to be here
 local function GetConfirmReloadText()
-    local confirmationText = ns.ch:T(L['Currently configured to load %s confirmation'])
+    local confirmationText = ns.ch:T(L['Currently set to switch profiles %s a confirmation prompt.'])
     local without      = L['without']
     local with         = L['with']
 
@@ -198,19 +198,19 @@ local function OnTooltipShow(self, tooltip)
     --@do-not-package@
     if ns:IsDev() then
         tooltip:AddDoubleLine(ORANGE_THREAT_COLOR:WrapTextInColorCode('SHIFT-LEFT-Click'),
-                              ns.ch:T(L['Open Debugging Dialog']))
+                              ns.ch:T(L['Open debug settings']))
     end
     --@end-do-not-package@
     tooltip:AddDoubleLine(ns.ch:S(L['LEFT-Click']), ns.ch:T(L['View or switch profiles']))
-    tooltip:AddDoubleLine(ns.ch:S(L['RIGHT-Click']), ns.ch:T(L['Open settings dialog']))
+    tooltip:AddDoubleLine(ns.ch:S(L['RIGHT-Click']), ns.ch:T(L['Open settings']))
 
-    tooltip:AddDoubleLine(ns.ch:S(L['SHIFT-RIGHT-Click']), ns.ch:T(L['Open minimap settings dialog']))
+    tooltip:AddDoubleLine(ns.ch:S(L['SHIFT-RIGHT-Click']), ns.ch:T(L['Open minimap settings']))
     tooltip:AddLine(' ')
     tooltip:AddLine(commandLines)
     local cmdLine = ns.sformat("/%s or /%s", C.CONSOLE_COMMAND_NAME, C.CONSOLE_COMMAND_SHORT)
     local cmdLineCfg = ns.sformat("/%s config", C.CONSOLE_COMMAND_SHORT)
     tooltip:AddDoubleLine(ns.ch:S(cmdLine), ns.ch:T(L['View available commands']))
-    tooltip:AddDoubleLine(ns.ch:S(cmdLineCfg), ns.ch:T(L['Open settings dialog']))
+    tooltip:AddDoubleLine(ns.ch:S(cmdLineCfg), ns.ch:T(L['Open settings']))
 
     if inSync then return end
 

--- a/Core/Lib/MinimapIconControllerMixin.lua
+++ b/Core/Lib/MinimapIconControllerMixin.lua
@@ -69,7 +69,7 @@ local function IsConfirmReload() return minimap().confirm_reloads == true end
 
 --- This local function is dynamic and needs to be here
 local function GetConfirmReloadText()
-    local confirmationText = ns.ch:T('Currently configured to load %s confirmation')
+    local confirmationText = ns.ch:T(L['Currently configured to load %s confirmation'])
     local without      = L['without']
     local with         = L['with']
 
@@ -198,7 +198,7 @@ local function OnTooltipShow(self, tooltip)
     --@do-not-package@
     if ns:IsDev() then
         tooltip:AddDoubleLine(ORANGE_THREAT_COLOR:WrapTextInColorCode('SHIFT-LEFT-Click'),
-                              ns.ch:T('Open Debugging Dialog'))
+                              ns.ch:T(L['Open Debugging Dialog']))
     end
     --@end-do-not-package@
     tooltip:AddDoubleLine(ns.ch:S(L['LEFT-Click']), ns.ch:T(L['View or switch profiles']))

--- a/Core/Lib/OptionsAddonsMixin.lua
+++ b/Core/Lib/OptionsAddonsMixin.lua
@@ -198,9 +198,6 @@ function o:CreateAddOnsOptions()
 
     --- @type table<string, AceConfigOption>
     local options = {
-        labelVersion = ACU:CreateLabelByName(versionLabel, {
-            order = order:next(),
-        }), spacer1a  = ACU:CreateSpacer(order:next()),
         showInQuickProfileSwitchMenu = ACU:CreateGlobalOption('Add to Favorite', {
             order = order:next(), type = "toggle", width = 'normal',
             get   = util:QuickProfileMenuGet(),

--- a/Core/Lib/OptionsMixin.lua
+++ b/Core/Lib/OptionsMixin.lua
@@ -67,7 +67,7 @@ function o:CreateOptions()
     self.order = order
     --- @type AceConfigOption
     local options = {
-        name = GC.C.FRIENDLY_NAME,
+        name = GC:GetAddOnTitle(),
         handler = self,
         type = "group",
         args = {


### PR DESCRIPTION
## Summary

Resolves #73, Locale Updates - expose new locale keys for confirmation text and debugging dialog; wrap minimap confirmation tooltip text with AceLocale lookups
Resolves #74, Add AddOn Version To Options Dialog

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691249cf8c68832ba9228ba8b8fe6139)